### PR TITLE
Update Mapping for json assets

### DIFF
--- a/mappings/digicat0_json.ttl
+++ b/mappings/digicat0_json.ttl
@@ -1209,27 +1209,6 @@ _:node1adimjjgvx1 a km-dev:R2RMLMapping ;
                 \"type\": \"other\"
             },
             {
-                \"name\": \"metaPropertyUri\",
-                \"value\": \"http://www.w3.org/ns/odrl/2/Offer\",
-                \"type\": \"other\"
-            },
-            {
-                \"name\": \"metaPropertyId\",
-                \"value\": \"http://www.w3.org/ns/odrl/2/Offer1\",
-                \"type\": \"other\"
-            },
-            {
-                \"name\": \"SemanticTypesArray\",
-                \"value\": [{
-                    \"isPrimary\": true,
-                    \"FullType\": \"http://isi.edu/integration/karma/dev#classLink\",
-                    \"DomainLabel\": \"http://www.w3.org/ns/odrl/2/Offer/Offer1 (add)\",
-                    \"DomainId\": \"http://www.w3.org/ns/odrl/2/Offer1\",
-                    \"DomainUri\": \"http://www.w3.org/ns/odrl/2/Offer\"
-                }],
-                \"type\": \"other\"
-            },
-            {
                 \"name\": \"trainAndShowUpdates\",
                 \"value\": true,
                 \"type\": \"other\"
@@ -2013,9 +1992,3 @@ km-dev:TriplesMap_8d678c04-72a1-4dd8-a3fe-754fb7cb10a5 rr:logicalTable _:node1ad
 	rr:subjectMap _:node1adimjjgvx16 .
 
 _:node1adimjjgvx1 km-dev:hasSubjectMap _:node1adimjjgvx16 .
-
-_:node1adimjjgvx16 km-dev:isPartOfMapping _:node1adimjjgvx1 ;
-	a rr:SubjectMap ;
-	km-dev:alignmentNodeId "http://www.w3.org/ns/odrl/2/Offer1" ;
-	rr:class <http://www.w3.org/ns/odrl/2/Offer> ;
-	rr:template "http://openpermissions.org/ns/id/{uuid}" .

--- a/mappings/digicat0_json.ttl
+++ b/mappings/digicat0_json.ttl
@@ -1209,6 +1209,27 @@ _:node1adimjjgvx1 a km-dev:R2RMLMapping ;
                 \"type\": \"other\"
             },
             {
+                \"name\": \"metaPropertyUri\",
+                \"value\": \"http://openpermissions.org/ns/op/1.1/Asset\",
+                \"type\": \"other\"
+            },
+            {
+                \"name\": \"metaPropertyId\",
+                \"value\": \"http://openpermissions.org/ns/op/1.1/Asset1\",
+                \"type\": \"other\"
+            },
+            {
+                \"name\": \"SemanticTypesArray\",
+                \"value\": [{
+                    \"isPrimary\": true,
+                    \"FullType\": \"http://isi.edu/integration/karma/dev#classLink\",
+                    \"DomainLabel\": \"http://openpermissions.org/ns/op/1.1/Asset/Asset1 (add)\",
+                    \"DomainId\": \"http://openpermissions.org/ns/op/1.1/Asset1\",
+                    \"DomainUri\": \"http://openpermissions.org/ns/op/1.1/Asset\"
+                }],
+                \"type\": \"other\"
+            },
+            {
                 \"name\": \"trainAndShowUpdates\",
                 \"value\": true,
                 \"type\": \"other\"
@@ -1992,3 +2013,9 @@ km-dev:TriplesMap_8d678c04-72a1-4dd8-a3fe-754fb7cb10a5 rr:logicalTable _:node1ad
 	rr:subjectMap _:node1adimjjgvx16 .
 
 _:node1adimjjgvx1 km-dev:hasSubjectMap _:node1adimjjgvx16 .
+
+_:node1adimjjgvx16 km-dev:isPartOfMapping _:node1adimjjgvx1 ;
+	a rr:SubjectMap ;
+	km-dev:alignmentNodeId "http://openpermissions.org/ns/op/1.1/Asset1" ;
+	rr:class <http://openpermissions.org/ns/op/1.1/Asset> ;
+	rr:template "http://openpermissions.org/ns/id/{uuid}" .

--- a/ontologies/odrl.rdf
+++ b/ontologies/odrl.rdf
@@ -1,0 +1,1461 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rdf:RDF xmlns:dcmit="http://purl.org/dc/dcmitype/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   xmlns:ont="http://purl.org/net/ns/ontology-annot#"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+   xmlns:vann="http://purl.org/vocab/vann/"
+   xmlns:voaf="http://purl.org/vocommons/voaf#"
+   xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+   xmlns="http://www.w3.org/ns/odrl/2/">
+  <owl:Ontology rdf:about="http://www.w3.org/ns/odrl/2/">
+    <dct:contributor>ODRL Community Group</dct:contributor>
+    <dct:creator>Mo McRoberts (BBC)</dct:creator>
+    <dct:creator>Víctor Rodríguez Doncel (OEG-UPM)</dct:creator>
+    <dct:description xml:lang="en">The Open Digital Rights Language (ODRL) provides flexible and interoperable mechanisms to support transparent and innovative use of digital content in publishing, distribution, and consumption of digital media across all sectors and communities. The ODRL Policy model is broad enough to support traditional rights expressions for commercial transaction, open access expressions for publicly distributed content, and privacy expressions for social media.</dct:description>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2015-03-05</dct:issued>
+    <dct:license rdf:resource="http://www.w3.org/community/about/agreements/final/"/>
+    <vann:example rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <vann:preferredNamespacePrefix>odrl</vann:preferredNamespacePrefix>
+    <vann:preferredNamespaceUri rdf:resource="http://w3.org/ns/odrl/2/"/>
+    <rdf:type rdf:resource="http://purl.org/vocommons/voaf#Vocabulary"/>
+    <rdfs:comment xml:lang="en">This is the RDF ontology for ODRL Version 2.1 (Final Specification, 5 March 2015) Copyright © 2015 the Contributors to the Final Specification, published by the W3C ODRL Community Group (https://www.w3.org/community/odrl/) under the W3C Community Final Specification Agreement (http://www.w3.org/community/about/agreements/final/). A human-readable summary is available (http://www.w3.org/community/about/agreements/fsa-deed/).</rdfs:comment>
+    <rdfs:label xml:lang="en">ODRL Version 2.1 Ontology</rdfs:label>
+    <owl:versionInfo>2.1</owl:versionInfo>
+  </owl:Ontology>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Action">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Instances of Action are things one might be permitted to do or prohibited from doing to a work.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Action</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Agreement">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Policy expressions that are formal contracts (or licenses) stipulating all the terms of usage and all the parties involved.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Agreement</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/All">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is all of the collective individuals within a context.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">All</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/All2ndConnections">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is all of the second-level connections to the Party.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">All second-level connections</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/AllConnections">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is all of the first-level connections of the Party.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">All connections</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/AllGroups">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is all of the group connections of the Party.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">All groups</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Asset">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Asset is anything which can be subject to a policy. Asserting that something the target of a policy implies that it is an Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Asset</rdfs:label>
+    <owl:equivalentClass rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/ConflictTerm">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Instances of ConflictTerm describe policies for resolving conflicts.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Conflict term</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Constraint">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Parent class of all Constraints.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Constraint</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Duty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A Duty is a rule which indicates requirements which must be fulfilled in order to receive the permission.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Duty</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Group">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is the defined group with multiple individual members.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Group</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Individual">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Specifies that the scope of the relationship is the single Party individual.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Individual</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <dcmit:Text rdf:about="http://www.w3.org/ns/odrl/2/ODRL21.html">
+    <dct:format rdf:resource="http://purl.org/NET/mediatypes/text/html"/>
+    <dct:isVersionOf rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">ODRL 2.1 (HTML)</rdfs:label>
+    <foaf:primaryTopic rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </dcmit:Text>
+  <dcmit:Text rdf:about="http://www.w3.org/ns/odrl/2/ODRL21.rdf">
+    <dct:format rdf:resource="http://purl.org/NET/mediatypes/application/rdf+xml"/>
+    <dct:isVersionOf rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">ODRL 2.1 (RDF/XML)</rdfs:label>
+    <foaf:primaryTopic rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </dcmit:Text>
+  <dcmit:Text rdf:about="http://www.w3.org/ns/odrl/2/ODRL21.ttl">
+    <dct:format rdf:resource="http://purl.org/NET/mediatypes/text/turtle"/>
+    <dct:isVersionOf rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">ODRL 2.1 (Turtle)</rdfs:label>
+    <foaf:primaryTopic rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </dcmit:Text>
+  <dcmit:Text rdf:about="http://www.w3.org/ns/odrl/2/ODRL21.xsd">
+    <dct:format rdf:resource="http://purl.org/NET/mediatypes/application/xml"/>
+    <dct:isVersionOf rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">ODRL 2.1 (XML Schema Definition)</rdfs:label>
+    <foaf:primaryTopic rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+  </dcmit:Text>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Offer">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An instance of Offer is a Policy expression that proposes terms of usage from an Asset owner.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Offer</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Operator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Instances of the Operator class represent boolean operators</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Operator</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Party">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An entity which can participate in policy transactions. Use an instance of the Party class where it's necessary to associate a Scope with the relationship; in other cases, simply reference the party directly.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Party</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Permission">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A Permission is a rule which indicates the actions the assignee is permitted to perform on the associated asset. In other words, what the assigner (supplier) has granted to the assignee (consumer).</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Permission</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Policy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A top level entity for describing policies.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Policy</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Privacy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An instance of Privacy is a Policy expression that stipulates the terms of usage over personal information.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Privacy</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Prohibition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">A Prohibition is a rule which indicates the Actions that the assignee is prohibited to perform on the related Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Prohibition</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Request">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An instance of Request is a Policy expression that proposes terms of usage to an Asset owner.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Request</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Rule">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An abstract common ancestor to Permissions, Prohibitions and Duties.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Rule</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Set">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An instance of Set is a Policy expression that consists of entities from the complete model.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Set</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Ticket"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/Ticket">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">An instance of Ticket is a Policy expression that stipulates the terms of usage and is redeemable by any Party who currently holds the Ticket in their possession.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Ticket</rdfs:label>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Agreement"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Offer"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Privacy"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Request"/>
+    <owl:disjointWith rdf:resource="http://www.w3.org/ns/odrl/2/Set"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/odrl/2/UndefinedTerm">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:comment xml:lang="en">Instances of UndefinedTerm describe policies for processing unsupported actions.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Undefined values</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdfs:Class>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/absolutePosition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">A point defined with absolute coordinates.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">absolute position</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/absoluteSize">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The absolute dimension that the Asset may be resized.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">absolute size</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/acceptTracking">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees accepts that the use of the Asset may be tracked. The collected information may be tracked by the Assigner, or may link to a Party with the role function “trackingParty”.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Accept tracking</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/action">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The operation relating to the asset for which permission is being granted. A permission must include exactly one action.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">action</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <skos:ConceptScheme rdf:about="http://www.w3.org/ns/odrl/2/actions">
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">ODRL Actions vocabulary</rdfs:label>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/acceptTracking"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/adHocShare"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/aggregate"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/annotate"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/anonymize"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/append"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/appendTo"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/archive"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/attachPolicy"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/attachSource"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/attribute"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/commercialize"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/compensate"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/concurrentUse"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/copy"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/delete"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/derive"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/display"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/distribute"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/ensureExclusivity"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/execute"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/export"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/extract"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/give"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/grantUse"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/include"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/index"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/inform"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/install"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/lease"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/lend"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/license"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/modify"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/move"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/nextPolicy"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/obtainConsent"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/pay"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/play"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/present"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/preview"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/print"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/read"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/reviewPolicy"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/secondaryUse"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/sell"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/share"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/shareAlike"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/textToSpeech"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/transform"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/translate"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/uninstall"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/watermark"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/write"/>
+    <skos:hasTopConcept rdf:resource="http://www.w3.org/ns/odrl/2/writeTo"/>
+  </skos:ConceptScheme>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/adHocShare">
+    <ont:deprecatedBy rdf:resource="http://www.openmobilealliance.com/oma-dd/adhoc-share"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of sharing the asset to parties in close proximity to the owner. This action may be used to express [OMA] Sharing semantics.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Ad-hoc sharing</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/aggregate">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to use the Asset or parts of it as part of a composite collection.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Aggregate</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/annotate">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to add explanatory notations/commentaries to the Asset without modifying the Asset in any other way.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Annotate</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/anonymize">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to anonymize all or parts of the Asset. For example, to remove identifying particulars for statistical or for other comparable purposes, or to use the asset without stating the author/source.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Anonymize</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/append">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/appendTo"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of adding to the end of an asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Append</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/appendTo">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of appending data to the Asset without modifying the Asset in any other way</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Append to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/writeTo"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/archive">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to store the Asset (in a non-transient form). Constraints may be used for temporal conditions.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Archive</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/assignee">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party is the recipient of the policy statement.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">assignee</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/assigner">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party is the issuer of the policy statement.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">assigner</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/attachPolicy">
+    <ont:deprecatedBy rdf:resource="http://creativecommons.org/ns#Notice"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of keeping the policy notice with the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Attach policy</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/attachSource">
+    <ont:deprecatedBy rdf:resource="http://creativecommons.org/ns#SourceCode"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of attaching the source of the asset and its derivatives.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Attach source</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/attribute">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees attributes the Asset to the Assigner or an attributed Party. May link to an Asset with the attribution information. May link to a Party with the role function “attributedParty”.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Attribute</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/attributedParty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party to be attributed.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">attributed party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/commercialize">
+    <ont:deprecatedBy rdf:resource="http://creativecommons.org/ns#CommercialUse"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of using the asset in a business environment.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Commercialize</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/compensate">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees compensates the Assigner (or other specified compensation Party) by some amount of value, if defined, for use of the Asset. The compensation may use different types of things with a value: (i) the thing is expressed by the value (term) of the Constraint name; (b) the value is expressed by operator, rightOperand, dataType and unit</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Compensate</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/compensatedParty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party is the recipient of the compensation.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">payee party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/concurrentUse">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to create multiple copies of the Asset that are being concurrently used.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Concurrent use</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/conflict">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relates a conflict-resolution mechansim to a Policy. If no mechanism is specified, the default is invalid.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">conflict</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/ConflictTerm"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/consentingParty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party to obtain consent from.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">consenting party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/constraint">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">One or more constraints which affect the validity of the Permission; e.g. if the Action play is only permitted for a certain period of time.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">constraint</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/copy">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of making an exact reproduction of the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Copy</rdfs:label>
+    <owl:sameAs rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/count">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The numeric count indicating the number of times the corresponding entity may be exercised</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">count</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/dataType">
+    <rdfs:comment xml:lang="en">The unit of measurement used for the constraint value.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">unit</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/dateTime">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The date (and optional time and timezone) representing a point in time or period.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">date/time</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/2001/XMLSchema#date"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/delete">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees permanently removes all copies of the Asset. Use a constraint to define under which conditions the Asset should be deleted.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Delete</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/deliveryChannel">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The delivery channel used for storing or communicating the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">delivery channel</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/derive">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to create a new derivative Asset from this Asset and to edit or modify the derivative. A new asset is created and may have significant overlaps with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the derived Asset a next policy may be applied.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Derive</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/device">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/systemDevice"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">An identifiable computing system.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">device</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/ns/odrl/2/system"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/digitize">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to produce a digital copy of (or otherwise digitize) the Asset from its analogue form.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Digitize</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/display">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to display the visual media Asset to an audience or the public. For example, displaying an image on a screen.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Display</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/present"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/distribute">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to distribute the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Distribute</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/duty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">A Duty indicates requirements which must be fulfilled in order to receive the permission.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">duty</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/elapsedTime">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">A period of time in which the policy action can be exercised.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">elapsed time</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/ensureExclusivity">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assignee requires that the Assigners ensure that the permission on the Asset is exclusive to the Assignee.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Ensure exclusivity</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/eq">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment xml:lang="en">Indicating that a given value equals the operand of the Constraint.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Equal to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/event">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Specification of a defined event applicable to the asset usage.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">event</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/execute">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to run the computer program Asset. For example, machine executable code or Java such as a game or application.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Execute</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/export">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/transform"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of transforming the asset into a new form.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Export</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/extract">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to extract parts of the Asset and to use it as a new Asset. A new asset is created and may have very little in common with the original Asset. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective). To the extracted Asset a next policy may be applied.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Extract</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/reproduce"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/extractChar">
+    <ont:deprecatedBy rdf:resource="http://www.editeur.org/onix-pl/extract-char"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of extracting (replicating) unchanged characters from the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Extract character</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+    <skos:broader rdf:resource="http://www.w3.org/ns/odrl/2/extract"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/extractPage">
+    <ont:deprecatedBy rdf:resource="http://www.editeur.org/onix-pl/extract-word"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of extracting (replicating) unchanged pages from the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Extract page</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+    <skos:broader rdf:resource="http://www.w3.org/ns/odrl/2/extract"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/extractWord">
+    <ont:deprecatedBy rdf:resource="http://www.editeur.org/onix-pl/extract-page"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of extracting (replicating) unchanged words from the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Extract word</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+    <skos:broader rdf:resource="http://www.w3.org/ns/odrl/2/extract"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/fileFormat">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The file format applicable to the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">file format</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/function">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Function is an abstract property whose sub-properties define the roles which may be fulfilled by a party in relation to a Rule.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">function</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/give">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to transfer the ownership of the Asset to a third party without compensation and while deleting the original asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Give</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/transfer"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/grantUse">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignee to grant the use the Asset to third parties. This action enables the Assignee to create policies for the use of the Asset for third parties. nextPolicy is recommended to be agreed with the third party. Use of temporal constraints is recommended.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Grant use</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/gt">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Greater than</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/gteq">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Greater than or equal to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/hasPart">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Has part</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <UndefinedTerm rdf:about="http://www.w3.org/ns/odrl/2/ignore">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment xml:lang="en">Undefined actions should be ignored.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Ignore</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </UndefinedTerm>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/include">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees include other related assets in the Asset. For example: bio picture must be included in the attribution. Use of the Asset relation attribute is required.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Include</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/index">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to record the Asset in an index. For example, to include a link to the Asset in a search engine database.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Index</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/industry">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The defined industry sector applicable to the asset usage</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">industry</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/inform">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees inform the Assigner or an informed Party that an action has been performed on or in relation to the Asset. May link to a Party with the role function “informedParty”.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Inform</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/informedParty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party to be informed of all uses.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">informed party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/inheritAllowed">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">A boolean value indicating whether this policy can be inherited from.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">inheritance allowed</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/inheritFrom">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relates a policy to another policy from which terms are inherited.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">inherits from</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/install">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to load the computer program Asset onto a storage device which allows operating or running the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Install</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <ConflictTerm rdf:about="http://www.w3.org/ns/odrl/2/invalid">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdf:type rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+    <rdfs:comment xml:lang="en">The policy is invalidated.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Invalid</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </ConflictTerm>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/isA">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Is a</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/isAllOf">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Is all of</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/isAnyOf">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Is any of</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/isNoneOf">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Is none of</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/isPartOf">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Is part of</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/language">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The natural language applicable to the asset usage</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">language</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/lease">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of making available the asset to a third-party for a fixed period of time with exchange of value.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Lease</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/lend">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of making available the asset to a third-party for a fixed period of time without exchange of value.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Lend</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/license">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/grantUse"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of granting the right to use the asset to a third-party.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">License</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/lt">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Less than</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/lteq">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Less than or equal to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/media">
+    <rdfs:comment xml:lang="en">The media type in which the asset may be used.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">media</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/meteredTime">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The maximum period of metered usage time.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">metered time</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/modify">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to update existing content of the Asset. A new asset is not created by this action. This action will modify an asset which is typically updated from time to time without creating a new asset like a database. If the result from modifying the asset should be a new asset the actions derive or extract should be used. (Note that the notion of whether or not the change is significant enough to qualify as a new asset is subjective).</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Modify</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/move">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to move the Asset from one digital location to another including deleting the original copy. After the Asset has been moved, the original copy must be deleted.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Move</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Operator rdf:about="http://www.w3.org/ns/odrl/2/neq">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Not equal to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Operator>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/nextPolicy">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees grants the specified Policy to a third party for their use of the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Next policy</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/obtainConsent">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees obtains explicit consent from the Assigner or a consenting Party to perform the requested action in relation to the Asset. Used as a Duty to ensure that the Assigner or a Party is authorized to approve such actions on a case-by-case basis. May link to a Party with the role function “consentingParty”.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Obtain consent</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/operator">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Boolean operator applied to a constraint and its operand.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">operator</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Operator"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/output">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The output property specifies the Asset which is created from the output of the Action.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">output</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/relation"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/pay">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/compensate"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of paying a financial amount to a party for use of the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Pay</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/payAmount">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">payment amount</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/payeeParty">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/compensatedParty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party is the recipient of the payment.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">payee party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/percentage">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The amount (as a percentage) of the action applicable to the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">percentage</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#decimal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <ConflictTerm rdf:about="http://www.w3.org/ns/odrl/2/perm">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment xml:lang="en">Permissions take precedence over prohibitions.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Permissions</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </ConflictTerm>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/permission">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relates the description of an individual Permission to a Policy. A permission can be specified either in terms of an Action alone, or an instance of Permission relating an Action and one or more other attributes.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">permission</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Permission"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/play">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to perform an audio Asset to an audience.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Play</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/present"/>
+  </Action>
+  <owl:NamedIndividual rdf:about="http://www.w3.org/ns/odrl/2/policyUsage">
+    <rdfs:comment xml:lang="en">When used as an event in constraints, indicates that the event occurs at the time when the policy is executed.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Policy usage time</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </owl:NamedIndividual>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/present">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to perform or exhibit an Asset to an audience.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Present</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/preview">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of providing a short preview of the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Preview</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/print">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to print an Asset onto paper or to create a hard copy. For example, creating a permanent, fixed (static), and directly perceivable representation of the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Print</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/present"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/product">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The specified Product or Service name.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">product</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/profile">
+    <rdfs:comment xml:lang="en">indicates the identifier of the ODRL Profile for which the policy expression conforms to</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">profile</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <ConflictTerm rdf:about="http://www.w3.org/ns/odrl/2/prohibit">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment xml:lang="en">Prohibitions take precedence over permissions.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Prohibit</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </ConflictTerm>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/prohibition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relates the description of an individual Prohibition to a Policy. A prohibition can be specified either in terms of an Action alone, or an instance of Prohibition relating an Action and one or more other attributes.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">prohibition</rdfs:label>
+    <rdfs:range>
+      <owl:Class>
+        <owl:unionOf>
+          <rdf:Description>
+            <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Prohibition"/>
+            <rdf:rest>
+              <rdf:Description>
+                <rdf:first rdf:resource="http://www.w3.org/ns/odrl/2/Action"/>
+                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"/>
+              </rdf:Description>
+            </rdf:rest>
+          </rdf:Description>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:range>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/proximity">
+    <ont:deprecatedBy rdf:resource="http://www.openmobilealliance.com/oma-dd/proximity"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">An value indicating the closeness or nearness.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">proximity</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/purpose">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Specification of a defined purpose applicable to the asset usage.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">purpose</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/read">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to obtain data from the Asset. For example, the ability to read a record from a database (the Asset).</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Read</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/recipient">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The party that receives the result of the Action on the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">recipient</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/relation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relation is an abstract property which creates an explicit link between an Action and an Asset. Sub-properties of relation are used to define the nature of that link.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">relation</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/relativePosition">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">A point defined with reference to another position.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">relative position</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/relativeSize">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The relative dimension that the Asset may be resized.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">relative size</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/reproduce">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of making an exact reproduction of the asset. The Assigner permits/prohibits the Assignees to make exact reproductions of the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Reproduce</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/resolution">
+    <rdfs:comment xml:lang="en">The resolution at which the asset may be used.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">resolution</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/reviewPolicy">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees have a person review the Policy applicable to the Asset. Used when human intervention is required to review the Policy. May link to an Asset which represents the full Policy information.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Review policy</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/rightOperand">
+    <rdfs:comment xml:lang="en">The operand applied to an instance of a constraint. Do not use the right-operand property directly within a Constraint. Instead, a Constraint instance must contain exactly one triple which makes use of one of the sub-properties of right-operand.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">right-operand</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/secondaryUse">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of using the asset for a purpose other than the purpose it was intended for.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Secondary use</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/sell">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to transfer the ownership of the Asset to a third party with compensation and while deleting the original asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Sell</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/transfer"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/share">
+    <ont:deprecatedBy rdf:resource="http://creativecommons.org/ns#Distribution"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of the non-commercial reproduction and distribution of the asset to third-parties.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Share</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/shareAlike">
+    <ont:deprecatedBy rdf:resource="http://creativecommons.org/ns#ShareAlike"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of distributing any derivative asset under the same terms as the original asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Share-alike</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/spatial">
+    <rdfs:comment xml:lang="en">A code representing a geospatial area.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">spatial</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/status">
+    <rdfs:comment xml:lang="en">The current value of the constraint. The range of the status property is identical to that of the operand property selected used in the constraint.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">status</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <UndefinedTerm rdf:about="http://www.w3.org/ns/odrl/2/support">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#NamedIndividual"/>
+    <rdfs:comment xml:lang="en">Undefined actions do not invalidate the policy, but notification for review must occur.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Support</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </UndefinedTerm>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/system">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/systemDevice"/>
+    <rdfs:comment xml:lang="en">An identifiable computing system.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">system</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/ns/odrl/2/device"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/systemDevice">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">An identifiable computing system.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">SystemDevice</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/ns/odrl/2/device"/>
+    <owl:equivalentProperty rdf:resource="http://www.w3.org/ns/odrl/2/system"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/target">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The target property specifies the Asset upon which the Action is performed.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Rule"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">target</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/relation"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/textToSpeech">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to have a text Asset read out loud to an audience.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Text-to-speech</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/timeInterval">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">Recurring period of time in which the usage may be exercised.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">time interval</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/timedCount">
+    <ont:deprecatedBy rdf:resource="http://www.openmobilealliance.com/oma-dd/timed-count"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:comment xml:lang="en">The number of seconds after which timed metering use of the asset begins.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">timed count</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>deprecated</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/trackingParty">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The Party is the usage tracker.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">tracking party</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/function"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/transfer">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner transfers/does not transfer the ownership in perpetuity to the Assignees.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Transfer</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/transform">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to make a digital copy of the digital Asset in another digital format. Typically used to convert the Asset into a different format for consumption on/transfer to a third party system.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Transform</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/translate">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignees to translate the original natural language of an Asset into another natural language. A new derivative Asset is created by that action.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Translate</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/undefined">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Relates the mechanism used for handling undefined actions to a Policy. If no mechanism is specified, the default is invalid.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">undefined</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/UndefinedTerm"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/uninstall">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees unload and delete the computer program Asset from a storage device and disable its readiness for operation. The Asset is no longer accessible to the Assignees.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Uninstall</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/unit">
+    <rdfs:comment xml:lang="en">The unit of measurement used for the constraint value.</rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/odrl/2/Constraint"/>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">unit</rdfs:label>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/use">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner permits/prohibits the Assignee to use the Asset as agreed. More details may be defined in the applicable agreements or under applicable commercial laws. Refined types of actions can be expressed by the narrower actions.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Use</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/version">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">The scope of versions for the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">version</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/odrl/2/virtualLocation">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:comment xml:lang="en">Specification of a digital locale.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">virtual location</rdfs:label>
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/odrl/2/rightOperand"/>
+    <vs:term_status>stable</vs:term_status>
+  </rdf:Property>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/watermark">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The Assigner requires that the Assignees apply a watermark as provided by the Assigner to the Asset. It is recommended to embed a link to the watermark.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Watermark</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/write">
+    <ont:deprecatedBy rdf:resource="http://www.w3.org/ns/odrl/2/writeTo"/>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of writing to the asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Write</rdfs:label>
+    <vs:term_status>deprecated</vs:term_status>
+  </Action>
+  <Action rdf:about="http://www.w3.org/ns/odrl/2/writeTo">
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <rdfs:comment xml:lang="en">The act of adding data to the Asset.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <rdfs:label xml:lang="en">Write to</rdfs:label>
+    <vs:term_status>stable</vs:term_status>
+    <skos:broaderTransitive rdf:resource="http://www.w3.org/ns/odrl/2/use"/>
+  </Action>
+</rdf:RDF>

--- a/ontologies/openpermissions.rdf
+++ b/ontologies/openpermissions.rdf
@@ -1,0 +1,557 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:dct="http://purl.org/dc/terms/"
+   xmlns:owl="http://www.w3.org/2002/07/owl#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+   xmlns:skos="http://www.w3c.org/2008/skos/"
+>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/selectRequired">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSelector"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#boolean"/>
+    <dc:description xml:lang="en">
+True if it is required to select an element on agreement of the policy.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/expires">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <dc:description xml:lang="en">
+Optional expiry date of the policy.
+The policy is not considered valid after this date.
+</dc:description>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/IRI">
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/id_types"/>
+    <skos:name xml:lang="en">IRI</skos:name>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <dc:description xml:lang="en">Id which has the form of an IRI</dc:description>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/top_id_type"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/defaultAssignee">
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <dc:description xml:lang="en">
+                                 Implicit default assignee of a rule.
+                                 </dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/anyEdgeDirection">
+    <skos:name xml:lang="en">anyEdgeDirection</skos:name>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirections"/>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/samplePolicy">
+    <dc:description xml:lang="en">
+The way asset are selected. Default is selected_by_assignee.
+</dc:description>
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSelector"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL456C9">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/edgeDirection"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/value">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Id"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/Asset">
+    <rdf:type rdf:nodeID="ub1bL63C9"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Asset</rdfs:label>
+    <rdf:type rdf:nodeID="ub1bL60C12"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Asset"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <dc:description xml:lang="en">
+An asset in ODRL is any object referred by a policy.
+
+Here the asset generally represents the intellectual work.
+Only metadata about the Asset that is required for the licensing of the Asset should be defined here.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/topIdType">
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/id_types"/>
+    <skos:name xml:lang="en">topIdType</skos:name>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/IdType">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">IdType</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:description xml:lang="en">
+Represents a class of identifiers
+</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/Party">
+    <rdfs:subClassOf rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdf:type rdf:nodeID="ub1bL178C9"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:nodeID="ub1bL175C12"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Party</rdfs:label>
+    <dc:description xml:lang="en">
+A party represent:
+  1. a legal person having duties and rights as part of agreements.
+  2. a person known by an organisation (not necessarily providing its real name)
+
+</dc:description>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Party"/>
+    <rdf:type rdf:nodeID="ub1bL181C9"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/targetObject">
+    <dc:description xml:lang="en">
+Indicates the entity that the elements must connect to through the predicate in order to be part of the set.
+Default is the AssetSet instance itself.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL271C9">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/digitalPolicyAuthor"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/Id">
+    <rdf:type rdf:nodeID="ub1bL114C9"/>
+    <dc:description xml:lang="en">
+Identifier for an asset.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Id</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:nodeID="ub1bL117C9"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL274C9">
+    <owl:onProperty rdf:resource="http://www.w3.org/ns/odrl/2/assigner"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/selectedByAssignee">
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anySamplePolicy"/>
+    <skos:name xml:lang="en">selectedByAssignee</skos:name>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies"/>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <dc:description xml:lang="en">chosen by the assignee party</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/chosenSequentially">
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <skos:name xml:lang="en">chosenSequentially</skos:name>
+    <dc:description xml:lang="en">chosen according to a predefined order</dc:description>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anySamplePolicy"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Ontology"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-02-22T10:56:00+00:00</dct:modified>
+    <dc:description rdf:datatype="http://www.w3.org/2001/XMLSchema#string">OpenPermissions Extension (ODRL2.1/ OpenPermissions Profile).</dc:description>
+    <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Digital Catapult Software Engineering Team</dc:creator>
+    <owl:versionIRI rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">1.1.0</owl:versionInfo>
+    <dct:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(C) Digital Catapult Limited 2016</dct:rights>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/policyDescription">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <dc:description xml:lang="en">A short description of the policy - usable to give a user rapidly information about the policy.</dc:description>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/description"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/provider">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <dc:description xml:lang="en">
+origanisation_id of the organisation representing the party.
+if no value is provider the party is the organisation itself
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL264C9">
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <owl:onProperty rdf:resource="http://www.w3.org/ns/odrl/2/target"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/predicate">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <dc:description xml:lang="en">
+Indicates which predicate is used to Indicate that element belong to a set.
+</dc:description>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/fromSet">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSelector"/>
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <dc:description xml:lang="en">
+The set asset can be picked from.
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL254C13">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/policyDescription"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/pointingFrom">
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:name xml:lang="en">pointingFrom</skos:name>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirections"/>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anyEdgeDirection"/>
+    <dc:description xml:lang="en">Point from the element to the target_object</dc:description>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/hasElement">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL460C9">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/hasElement"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:allValuesFrom rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL452C15">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/targetObject"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:allValuesFrom rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL413C20">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/selectRequired"/>
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL420C9">
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/count"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/policyText">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+    <dc:description xml:lang="en">The policy 'small print'</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/Policy">
+    <rdf:type rdf:nodeID="ub1bL274C9"/>
+    <rdf:type rdf:nodeID="ub1bL268C9"/>
+    <rdf:type rdf:nodeID="ub1bL264C9"/>
+    <rdf:type rdf:nodeID="ub1bL257C9"/>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/odrl/2/Policy"/>
+    <rdf:type rdf:nodeID="ub1bL254C13"/>
+    <rdf:type rdf:nodeID="ub1bL260C9"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:description xml:lang="en">
+An ODRL policy representing an agreement or a potential agreement.
+
+Policy is the central entity that holds an ODRL policy together. In its encoded form, e.g. in an XML document, it makes the policy addressable from the outside word via its uid attribute. Policy can refer to Permissions and Prohibitions.
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:nodeID="ub1bL271C9"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Policy</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL423C9">
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/fromSet"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL463C9">
+    <owl:allValuesFrom rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/predicate"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL260C9">
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://www.w3.org/ns/odrl/2/assignee"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL178C9">
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/provider"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/name">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/name"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/pointingTo">
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirections"/>
+    <skos:name xml:lang="en">pointingTo</skos:name>
+    <dc:description xml:lang="en">Point from the target_object to the element</dc:description>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection"/>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anyEdgeDirection"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/selectedByAssigner">
+    <dc:description xml:lang="en">chosen by the assigner party</dc:description>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anySamplePolicy"/>
+    <skos:name xml:lang="en">selectedByAssigner</skos:name>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <dc:description xml:lang="en">
+Indicates if the predicate used to connect the set to its elements,
+are "pointing to" the elements or "pointing from" the elements
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AssetSetEdgeDirection</rdfs:label>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/Hubkey">
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/top_id_type"/>
+    <dc:description xml:lang="en">Id who has the form of a Hubkey.  This refers to the latest schema of a Hubkey.</dc:description>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+    <skos:name xml:lang="en">Hubkey</skos:name>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/id_types"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/edgeDirection">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <dc:description xml:lang="en">
+Indicates in which direction the predicate is used to connect elements to the set target_object.
+Default is op:pointingTo.
+</dc:description>
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirection"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/anySamplePolicy">
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies"/>
+    <skos:name xml:lang="en">anySamplePolicy</skos:name>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/alsoIdentifiedBy">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <dc:description xml:lang="en">
+    An Asset may have different identifiers assigned to it by different parties.
+    The identities are not necessarily equivalent even though they have been assigned to the same Asset.
+    Each identity has a type, such as ISBN or EIDR and the type is semantically defined.
+    Identities that alsoIdentifiedBy refer to MUST be for the whole Asset and not for part of the Asset.
+    	For example if the Asset is a book, the alsoIdentifiedBy ids will be for the book and NOT for pictures in the book.
+</dc:description>
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/Id"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL114C9">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/value"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/count">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSelector"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <dc:description xml:lang="en">
+Default value is 1.
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSelector">
+    <rdf:type rdf:nodeID="ub1bL416C9"/>
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AssetSelector</rdfs:label>
+    <rdf:type rdf:nodeID="ub1bL413C20"/>
+    <rdfs:subClassOf rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <rdf:type rdf:nodeID="ub1bL423C9"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:nodeID="ub1bL420C9"/>
+    <dc:description xml:lang="en">
+An asset that is actually sampled from a set. An AssetSetSample must indicate the set asset must be selected from, m
+ay contain a sample policy,  and may contain the number of assets that should be sampled.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/reference">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <dc:description xml:lang="en">
+An reference id used by the provider to actually identify the party
+</dc:description>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/source"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Party"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL268C9">
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/expires"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL175C12">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/reference"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSetEdgeDirections">
+    <skos:hasTopConcept rdf:resource="http://openpermissions.org/ns/op/1.1/anyEdgeDirection"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/HubkeyS0">
+    <skos:name xml:lang="en">HubkeyS0</skos:name>
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/id_types"/>
+    <dc:description xml:lang="en">Id who has the form of a Hubkey.  This refers to schema 0 of the Hubkey.</dc:description>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/top_id_type"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/digitalPolicyAuthor">
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <dc:description xml:lang="en">
+A field to allow the author of the digital policy - if available this person may be
+eventually be contacted to obtain information about the policy.
+</dc:description>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/id_type">
+    <rdfs:range rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Id"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/title">
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+    <dc:description xml:lang="en">
+Title of the asset for the purpose of presentation to a Licensee.
+</dc:description>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/elements/1.1/title"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/randomlyChosen">
+    <rdf:type rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <skos:narrowerThan rdf:resource="http://openpermissions.org/ns/op/1.1/anySamplePolicy"/>
+    <skos:name xml:lang="en">randomlyChosen</skos:name>
+    <dc:description xml:lang="en">chosen in an arbitrary manner not controller by assignee or assigner</dc:description>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/Concept"/>
+    <skos:inScheme rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSet">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AssetSet</rdfs:label>
+    <rdf:type rdf:nodeID="ub1bL460C9"/>
+    <rdf:type rdf:nodeID="ub1bL452C15"/>
+    <rdfs:subClassOf rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSet"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdf:type rdf:nodeID="ub1bL456C9"/>
+    <rdfs:subClassOf rdf:resource="http://openpermissions.org/ns/op/1.1/Asset"/>
+    <rdf:type rdf:nodeID="ub1bL463C9"/>
+    <dc:description xml:lang="en">
+A set defined as the set of element pointing to a target object via a certain predicate.
+</dc:description>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <dc:description xml:lang="en">
+A set or collection of elements of type elementType
+</dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL60C12">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/title"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL63C9">
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/Id"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/alsoIdentifiedBy"/>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL257C9">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://www.w3.org/ns/odrl/2/duty"/>
+    <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/sharedDuties">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#ObjectProperty"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/odrl/2/Duty"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <rdfs:domain rdf:resource="http://openpermissions.org/ns/op/1.1/Policy"/>
+    <dc:description xml:lang="en">
+                                 Duties that are shared by all Permissions in this policy.
+                                 </dc:description>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL416C9">
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/samplePolicy"/>
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy"/>
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicies">
+    <skos:hasTopConcept rdf:resource="http://openpermissions.org/ns/op/1.1/anySamplePolicy"/>
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/ConceptScheme"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL117C9">
+    <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:allValuesFrom rdf:resource="http://openpermissions.org/ns/op/1.1/IdType"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/id_type"/>
+  </rdf:Description>
+  <rdf:Description rdf:nodeID="ub1bL181C9">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Restriction"/>
+    <owl:onProperty rdf:resource="http://openpermissions.org/ns/op/1.1/name"/>
+    <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/id_types">
+    <rdf:type rdf:resource="http://www.w3c.org/2008/skos/ConceptScheme"/>
+    <skos:hasTopConcept rdf:resource="http://openpermissions.org/ns/op/1.1/topIdType"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://openpermissions.org/ns/op/1.1/AssetSetSamplePolicy">
+    <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">AssetSetSamplePolicy</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <rdfs:isDefinedBy rdf:resource="http://openpermissions.org/ns/op/1.1/"/>
+    <dc:description xml:lang="en">
+Indicates the way sampling from a set is done.
+</dc:description>
+  </rdf:Description>
+</rdf:RDF>


### PR DESCRIPTION
We found that assets onboarded using json ended up with triples:
id rdf:type op:Asset 
AND 
id rdf:type odrl:Offer.

This was causing problems as assets were then incorrectly identified as offers.

This is to remove the odrl:Offer triple from assets transformed from json
